### PR TITLE
Refactor to make callbacks idiomatic

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -10,7 +10,7 @@ var PlayMusic = require('../');
 var pm = new PlayMusic();
 var config = JSON.parse(fs.readFileSync("config.json"));
 pm.init(config, function() {
-    pm.getLibrary(function(library) {
+    pm.getLibrary(function(err, library) {
         var song = library.data.items.pop();
         console.log(song);
         pm.getStreamUrl(song.id, function(streamUrl) {
@@ -18,25 +18,27 @@ pm.init(config, function() {
         });
     });
 
-    pm.search("bastille lost fire", 5, function(data) {
+    pm.search("bastille lost fire", 5, function(err, data) {
         var song = data.entries.sort(function(a, b) {
             return a.score < b.score;
         }).shift();
         console.log(song);
-        pm.getStreamUrl(song.track.nid, function(streamUrl) {
+        pm.getStreamUrl(song.track.nid, function(err, streamUrl) {
             console.log(streamUrl);
         });
     }, function(err) {
         console.log(err);
     });
 
-    pm.getPlayLists(function(data) {
+    pm.getPlayLists(function(err, data) {
         console.log(data.data.items);
     });
 
-    pm.getPlayListEntries(function(data) {
+    pm.getPlayListEntries(function(err, data) {
         console.log(data.data.items);
     });
 
-    pm.getStreamUrl("Thvfmp2be3c7kbp6ny4arxckz54", console.log);
+    pm.getStreamUrl("Thvfmp2be3c7kbp6ny4arxckz54", function(err, data) {
+        console.log(data);
+    });
 });


### PR DESCRIPTION
The API to the library could do with following established node idioms for callbacks.

Apart from being more straightforward to work with, it would allow other libraries to make assumptions about it (for example, bluebird's promisifyAll)

I'm already using the library with the modifications in production and it passes all of the existing tests, and the tests in my own codebase that rely on it.

There's more work to be done before this could be merged, so I'm opening a pull request for a discussion.