### PR TITLE
removed console output in .init

### DIFF
--- a/play.js
+++ b/play.js
@@ -171,8 +171,6 @@ PlayMusic.prototype._oauth =  function (callback) {
             //Authorization: "GoogleLogin auth=" + that._master_token
         }
     },  function(err, data) {
-        console.error(err);
-        //console.log(data);
         callback(err, err ? null : pmUtil.parseKeyValues(data));
     });
 };


### PR DESCRIPTION
There was a `console.error(err);` which caused console output when calling `.init(...)`.