### PR TITLE
Added getStream()

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "crypto-js": ">= 3.1",
+    "lame": "github:tootallnate/node-lame",
     "node-uuid": "~1.4.1"
   }
 }

--- a/play.js
+++ b/play.js
@@ -16,6 +16,7 @@ var CryptoJS = require("crypto-js");
 var uuid = require('node-uuid');
 var util = require('util');
 var crypto = require('crypto');
+var lame = require('lame');
 //var async = require('async');
 
 var pmUtil = {};
@@ -305,6 +306,23 @@ PlayMusic.prototype.getStreamUrl = function (id, callback) {
         }
     });
 };
+
+/**
+ * Opens and returns a PCM signed 16-bit LE stream for a track.
+ *
+ * @param id string - track id, hyphenated is preferred, but "nid" will work for all access tracks (not uploaded ones)
+ * @param callback function(stream) - success callback
+ */
+PlayMusic.prototype.getStream = function(id, callback) {
+    this.getStreamUrl(id, function(err, url) {
+        if(err) return callback(err);
+        https.get(url, function(stream) {
+            stream = stream.pipe(lame.Decoder());
+            callback(null, stream);
+        })
+
+    })
+}
 
 /**
  * Searches for All Access tracks.


### PR DESCRIPTION
We can get a stream url, hey, why not just open the stream for you? The stream is automatically decoded into PCM signed 16-bit LE so pipe it into any stream that takes that.