### PR TITLE
handle clientside http error

### DIFF
--- a/play.js
+++ b/play.js
@@ -92,6 +92,12 @@ PlayMusic.prototype.request = function(options, callback) {
             if(typeof callback === "function") callback(err, body, res);
         });
     });
+    req.on('error', function (error) {
+        var err = new Error("Error making https request");
+        err.error = err;
+        if (typeof callback === "function") callback(err, null, null);
+        return;
+    });
     if(typeof options.data !== "undefined") req.write(options.data);
     req.end();
 };


### PR DESCRIPTION
I always get an uncaught exception when I try to use the playmusic API with a broken connection to the internet. This pull request handles these clientside errors.