### PR TITLE
fix bug with setting android id

### DIFF
--- a/play.js
+++ b/play.js
@@ -181,6 +181,7 @@ PlayMusic.prototype._oauth =  function (callback) {
 PlayMusic.prototype.login =  function (opt, callback) {
     var that = this;
     opt.androidId = opt.androidId || crypto.pseudoRandomBytes(8).toString("hex");
+    that._androidId = opt.androidId;
     var data = {
         accountType: "HOSTED_OR_GOOGLE",
         Email: opt.email.trim(),


### PR DESCRIPTION
I found that in the `_oauth` function it is sending a blank `androidId`.. See https://github.com/jamon/playmusic/blob/master/play.js#L151

the variable `_androidId` is never set

Yesterday google started rejecting my requests..  Even changing my password, etc didn't help.  Once I added this line it started working 😩  